### PR TITLE
Change Password Fixed

### DIFF
--- a/ui/LoginFrame.py
+++ b/ui/LoginFrame.py
@@ -74,10 +74,6 @@ class LoginFrame(ctk.CTkFrame):
         self.register_button = createButton(self.submit_frame, 'Register',command=lambda: self.controller.show_page("Register") )
         self.register_button.grid(row=1, column=1, sticky='e')
 
-        # change password button
-        change_password_button = createButton(self.submit_frame, 'Change Password', command=lambda: self.controller.do_change_password(self))
-        change_password_button.grid(row=2, column=0, padx=(0, 10), pady=(0, 10), sticky='w')
-
 if __name__ == "__main__":
     ctk.set_appearance_mode("light")
     ctk.set_default_color_theme("blue")

--- a/ui/ProfileFrame.py
+++ b/ui/ProfileFrame.py
@@ -6,15 +6,53 @@ class ProfileFrame(tk.Frame):
     def __init__(self, parent, controller):
         super().__init__(parent, bg="white")
         self.controller = controller
-        tk.Label(self, text="User Profile").pack(pady=20)
+        tk.Label(self, text="User Profile", font=("Arial", 18)).pack(pady=(30, 10))
 
-        tk.Button(self, text="View Saved Courses", command=self.display_saved).pack()
+        tk.Button(self, text="View Saved Courses", command=self.display_saved).pack(pady=(0, 15))
+
+        account_link = tk.Label(self, text="Account details", fg="#1a73e8", cursor="hand2", font=("Arial", 10, "underline"), bg="white")
+        account_link.pack()
+        account_link.bind("<Button-1>", lambda _event: self.open_account_details())
+
+    def open_account_details(self):
+        account_page = self.controller.pages.get("Account Details")
+        if account_page:
+            account_page.refresh_email(getattr(self.controller, "current_user_email", None))
+        self.controller.buttonClicked("Account Details")
 
     def display_saved(self):
         results = queries.get_saved(self.controller.user)
-        self.controller.currentPage.pack_forget()
+        if self.controller.currentPage:
+            self.controller.currentPage.grid_remove()
         self.controller.pages["Saved"].update_results(results)
         self.controller.buttonClicked("Saved")
+
+class AccountDetailsFrame(tk.Frame):
+    def __init__(self, parent, controller):
+        super().__init__(parent, bg="white")
+        self.controller = controller
+
+        top = tk.Frame(self, bg="white")
+        top.pack(fill="x", pady=(10, 20))
+
+        tk.Button(top, text="Back", command=lambda: controller.buttonClicked("Profile")).pack(side="left", padx=10)
+        tk.Label(top, text="Account Details", font=("Arial", 16), bg="white").pack(side="left", padx=10)
+
+        info = tk.Frame(self, bg="white")
+        info.pack(pady=(0, 20))
+
+        tk.Label(info, text="Email:", font=("Arial", 12, "bold"), bg="white").grid(row=0, column=0, sticky="e", padx=5)
+        self.email_value = tk.Label(info, text="", font=("Arial", 12), bg="white")
+        self.email_value.grid(row=0, column=1, sticky="w")
+
+        change_password = tk.Button(self, text="Change Password", command=lambda: controller.do_change_password(self))
+        change_password.pack(pady=(0, 10))
+
+    def refresh_email(self, email):
+        if email:
+            self.email_value.configure(text=email)
+        else:
+            self.email_value.configure(text="Unavailable")
 
 class SavedFrame(tk.Frame):
     def __init__(self, parent, controller):

--- a/ui/gui.py
+++ b/ui/gui.py
@@ -84,6 +84,7 @@ class App(ctk.CTk):
             "Courses": CourseFrame(self.mainArea, self),
             "Sections": SectionFrame(self.mainArea, self),
             "Profile": ProfileFrame(self.mainArea, self),
+            "Account Details": AccountDetailsFrame(self.mainArea, self),
             "Saved": SavedFrame(self.mainArea, self),
             "Help": HelpFrame(self.mainArea)
         }
@@ -154,7 +155,10 @@ class App(ctk.CTk):
             return
         try:
             msg = self.provider.register_user(full_name, email, password)
-            messagebox.showinfo("Verify", msg)
+            messagebox.showinfo(
+                "Verify",
+                msg.get("message") if isinstance(msg, dict) else str(msg)
+            )
 
             code = simpledialog.askstring(
                 "Confirm", f"Enter the 6-digit code sent to {email}")


### PR DESCRIPTION
Removed the Change Password feature from the login page to the profile page. If a user wanted to change their password they could go under Account details in the profile page where they will be directed to a new page that displays their email and the Change Password button. Also changed the text that is displayed when successfully registering an account so that only what is wanted to be display is included and none of the raw text is displayed.